### PR TITLE
Add `gh_environment` line to workflows

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       app_name: fdk-mqa-scoring-api
       environment: prod
+      gh_environment: prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,6 +30,7 @@ jobs:
     with:
       app_name: fdk-mqa-scoring-api
       environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +44,7 @@ jobs:
     with:
       app_name: fdk-mqa-scoring-api
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -21,6 +21,7 @@ jobs:
     with:
       app_name: fdk-mqa-scoring-api
       environment: staging
+      gh_environment: staging
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
     with:
       app_name: fdk-mqa-scoring-api
       environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `gh_environment: <env>` after each `environment: <env>` line in key workflows.